### PR TITLE
fix: ALFA wiki link was 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 ### Policy Standards
 
 - [XACML](https://en.wikipedia.org/wiki/XACML) - XML-based standard for ABAC policies. Mature but verbose.
-- [ALFA](https://en.wikipedia.org/wiki/ALFA_\(authorization\)) - Human-readable DSL for writing XACML policies.
+- [ALFA](https://en.wikipedia.org/wiki/Abbreviated_Language_for_Authorization) - Human-readable DSL for writing XACML policies.
 
 ### Cloud Native
 


### PR DESCRIPTION
The previous URL (`ALFA_(authorization)`) doesn't exist on Wikipedia. Real article is at `Abbreviated_Language_for_Authorization`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the ALFA policy standards reference link.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kanywst/awesome-authorization/pull/3)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->