### PR TITLE
chore: point CNCF TAG-Security to its website

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 
 ### Cloud Native
 
-- [CNCF TAG-Security](https://github.com/cncf/tag-security) - CNCF Technical Advisory Group covering authorization, policy, and security.
+- [CNCF TAG-Security](https://tag-security.cncf.io/) - CNCF Technical Advisory Group covering authorization, policy, and security. (GitHub repo archived Dec 2025; website is the current home.)
 
 ## Authorization as a Service
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 
 ### Cloud Native
 
-- [CNCF TAG-Security](https://tag-security.cncf.io/) - CNCF Technical Advisory Group covering authorization, policy, and security. (GitHub repo archived Dec 2025; website is the current home.)
+- [CNCF TAG-Security](https://tag-security.cncf.io/) - CNCF Technical Advisory Group covering authorization, policy, and security. GitHub repo archived Dec 2025.
 
 ## Authorization as a Service
 


### PR DESCRIPTION
The `cncf/tag-security` repo was archived in December 2025. The working group still operates and points everyone to tag-security.cncf.io now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CNCF TAG-Security reference to point to the official CNCF TAG-Security website (tag-security.cncf.io) instead of the archived GitHub repository.
  * Added a note that the GitHub repository was archived in Dec 2025, so documentation now directs users to the maintained TAG-Security site.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kanywst/awesome-authorization/pull/4)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->