### PR TITLE
Drop Aserto from Authorization as a Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 - [Auth0 Fine Grained Authorization](https://auth0.com/fine-grained-authorization) - Managed OpenFGA by Auth0/Okta.
 - [Authzed](https://authzed.com/) - Managed SpiceDB. Zanzibar-style fine-grained permissions.
 - [Permit.io](https://www.permit.io/) - Full-stack authorization with a policy management UI and OPAL.
-- [Aserto](https://www.aserto.com/) - Cloud-native authz built on Topaz (OPA + Zanzibar).
 - [Oso Cloud](https://www.osohq.com/oso-cloud) - Managed authorization using the Polar policy language.
 - [Cerbos Hub](https://www.cerbos.dev/product-cerbos-hub) - Managed Cerbos policy deployment and testing.
 - [Amazon Verified Permissions](https://aws.amazon.com/verified-permissions/) - Managed Cedar-based authorization service by AWS.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 - [OpenFGA](https://github.com/openfga/openfga) - Fine-grained authorization engine, originally from Auth0. CNCF Incubating project.
 - [Permify](https://github.com/Permify/permify) - Zanzibar-inspired authorization service for fine-grained access control. Acquired by FusionAuth in 2025.
 - [Ory Keto](https://github.com/ory/keto) - Go implementation of Zanzibar. Part of the Ory ecosystem.
-- [Topaz](https://github.com/aserto-dev/topaz) - Combines Zanzibar model with OPA. By Aserto.
+- [Topaz](https://github.com/aserto-dev/topaz) - Open-source authorizer combining the Zanzibar model with OPA.
 - [Warrant](https://github.com/warrant-dev/warrant) - Fine-grained authorization engine, Zanzibar-inspired.
 
 ### Kubernetes-Native


### PR DESCRIPTION
Aserto wound down the commercial offering in April 2025 ("The final chapter for Aserto — Goodbye Aserto, long live Topaz"). Topaz remains listed under Zanzibar-Based, which is where the work continues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the "Aserto" managed service entry from the Authorization as a Service list.
  * Shortened the "Topaz" description in the Zanzibar-Based section to "Open-source authorizer combining the Zanzibar model with OPA."

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kanywst/awesome-authorization/pull/5)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->