### PR TITLE
Drop deprecated Oso OSS library

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@
 - [Cedar](https://www.cedarpolicy.com/) - Policy language and engine by AWS. Designed to be analyzable and expressive.
 - [Casbin](https://casbin.org/) - Supports ACL, RBAC, ABAC, etc. Has adapters for many languages and storage backends.
 - [Cerbos](https://cerbos.dev/) - Self-hosted authorization layer. Policies are defined in YAML/JSON with built-in testing support.
-- [Oso](https://www.osohq.com/) - Comes with Polar, a declarative policy language for application-level authorization.
 - [Open Policy Administration Layer (OPAL)](https://github.com/permitio/opal) - Keeps policies and data in sync across policy engines in real time.
 
 ### Zanzibar-Based


### PR DESCRIPTION
`osohq/oso` has been deprecated since end of 2023 (no releases since v0.27.1, Dec 2023). Oso Cloud is still alive and stays listed under Authorization as a Service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed a policy engine entry from the Policy Engines & Frameworks section in the documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kanywst/awesome-authorization/pull/6)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->