### PR TITLE
Remove self-authored OPA AuthZEN plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 
 ### AuthZEN Implementations
 
-- [OPA AuthZEN Plugin](https://github.com/kanywst/opa-authzen-plugin) - OPA plugin that implements the OpenID AuthZEN Authorization API.
 - Cerbos - Has AuthZEN PDP API support. See [General Purpose](#general-purpose).
 - [Topaz](https://www.topaz.sh/) - Has AuthZEN evaluation API support. See [Zanzibar-Based](#zanzibar-based).
 


### PR DESCRIPTION
Self-promotion is one of the things awesome-list reviewers explicitly look for. `kanywst/opa-authzen-plugin` only has 2 stars and no external adoption — not worth a slot here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an obsolete entry from the AuthZEN implementations documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kanywst/awesome-authorization/pull/7)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->