### PR TITLE
Add WorkOS FGA

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 - [Oso Cloud](https://www.osohq.com/oso-cloud) - Managed authorization using the Polar policy language.
 - [Cerbos Hub](https://www.cerbos.dev/product-cerbos-hub) - Managed Cerbos policy deployment and testing.
 - [Amazon Verified Permissions](https://aws.amazon.com/verified-permissions/) - Managed Cedar-based authorization service by AWS.
-- [WorkOS FGA](https://workos.com/fine-grained-authorization) - Zanzibar-based FGA service (originally Warrant, acquired by WorkOS in 2024).
+- [WorkOS FGA](https://workos.com/fine-grained-authorization) - Zanzibar-based FGA service built on the Warrant engine.
 - [Axiomatics](https://www.axiomatics.com/) - Enterprise ABAC platform.
 - [PlainID](https://www.plainid.com/) - Policy-based access control for enterprises.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 - [Oso Cloud](https://www.osohq.com/oso-cloud) - Managed authorization using the Polar policy language.
 - [Cerbos Hub](https://www.cerbos.dev/product-cerbos-hub) - Managed Cerbos policy deployment and testing.
 - [Amazon Verified Permissions](https://aws.amazon.com/verified-permissions/) - Managed Cedar-based authorization service by AWS.
+- [WorkOS FGA](https://workos.com/fine-grained-authorization) - Zanzibar-based FGA service (originally Warrant, acquired by WorkOS in 2024).
 - [Axiomatics](https://www.axiomatics.com/) - Enterprise ABAC platform.
 - [PlainID](https://www.plainid.com/) - Policy-based access control for enterprises.
 


### PR DESCRIPTION
Zanzibar-based managed authorization. Built on the former Warrant product (WorkOS acquired Warrant in April 2024 and re-launched it as WorkOS FGA).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "WorkOS FGA" to the README’s list of authorization services, including a brief description and link.
  * Placed the new entry between "Amazon Verified Permissions" and "Axiomatics" to maintain list order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kanywst/awesome-authorization/pull/9)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->