### PR TITLE
Add MCP authorization spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 - [UMA 2.0 (User-Managed Access)](https://docs.kantarainitiative.org/uma/wg/rec-oauth-uma-grant-2.0.html) - OAuth-based protocol enabling users to control access to their resources.
 - [GNAP](https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol) - Grant Negotiation and Authorization Protocol. Next-gen successor to OAuth.
 
+### Agent & AI Authorization
+
+- [MCP Authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) - OAuth 2.1-based authorization model in the Model Context Protocol. Defines how AI clients obtain and present tokens to MCP servers.
+
 ### Workload Identity
 
 - [SPIFFE](https://spiffe.io/) - Secure Production Identity Framework for Everyone. Provides cryptographic identity to workloads (CNCF).


### PR DESCRIPTION
The Model Context Protocol now has a formal OAuth 2.1-based authorization model (2025-11-25 spec). Added a small new subsection "Agent & AI Authorization" under Standards & Specifications since this is going to be the main place future agent-related authz standards land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Agent & AI Authorization subsection to Standards & Specifications, documenting MCP Authorization as an OAuth 2.1-based authorization model for the Model Context Protocol, including token handling procedures for AI clients and servers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kanywst/awesome-authorization/pull/10)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->