### PR TITLE
Add Slack and Notion real-world entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ How companies do authorization at scale.
 - [Lyft Airflow DAG-Level Access](https://eng.lyft.com/securing-apache-airflow-ui-with-dag-level-access-a7bc649a2821) - DAG-level access control on Airflow.
 - [AppsFlyer Microservices Authorization](https://medium.com/appsflyerengineering/authorization-solution-for-microservices-architecture-a2ac0c3c510b) - Authz patterns in microservices.
 - [Ubicloud ABAC Learnings](https://www.ubicloud.com/blog/learnings-from-building-a-simple-authorization-system-abac) - Lessons from building a simple ABAC system.
+- [Slack Role Management](https://slack.engineering/role-management-at-slack/) - Slack's transition from coarse roles to granular RBAC with a dedicated Go permissions service.
+- [Notion: Security in Custom Agents](https://www.notion.com/blog/how-we-built-security-into-custom-agents) - Permission model for AI agents acting on behalf of users in shared workspaces.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ How companies do authorization at scale.
 - [AppsFlyer Microservices Authorization](https://medium.com/appsflyerengineering/authorization-solution-for-microservices-architecture-a2ac0c3c510b) - Authz patterns in microservices.
 - [Ubicloud ABAC Learnings](https://www.ubicloud.com/blog/learnings-from-building-a-simple-authorization-system-abac) - Lessons from building a simple ABAC system.
 - [Slack Role Management](https://slack.engineering/role-management-at-slack/) - Slack's transition from coarse roles to granular RBAC with a dedicated Go permissions service.
-- [Notion: Security in Custom Agents](https://www.notion.com/blog/how-we-built-security-into-custom-agents) - Permission model for AI agents acting on behalf of users in shared workspaces.
+- [Notion Custom Agent Security](https://www.notion.com/blog/how-we-built-security-into-custom-agents) - Permission model for AI agents acting on behalf of users in shared workspaces.
 
 ## Security
 


### PR DESCRIPTION
Two solid case studies that weren't in the list yet:

- Slack engineering's writeup on rolling out their granular RBAC service.
- Notion's recent (Feb 2026) post on building the permission model for AI agents in shared workspaces — the kind of agent-authz writeup that's still rare.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Slack Role Management" real-world implementation example to the README, illustrating Slack's move toward more granular role-based access control with a dedicated permissions service; placed immediately before the existing "Notion Custom Agent Security" entry to enhance the collection of practical security and access-control patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kanywst/awesome-authorization/pull/11)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->