### PR TITLE
add Keycloak to AuthZEN Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 
 - Cerbos - Has AuthZEN PDP API support. See [General Purpose](#general-purpose).
 - [Topaz](https://www.topaz.sh/) - Has AuthZEN evaluation API support. See [Zanzibar-Based](#zanzibar-based).
+- [Keycloak](https://www.keycloak.org/2026/05/authzen-as-experimental-feature) - Ships experimental AuthZEN PDP support as of Keycloak 26.7, exposing the Evaluations API and `.well-known/authzen-configuration`.
 
 ### Language-Specific Libraries
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 
 - Cerbos - Has AuthZEN PDP API support. See [General Purpose](#general-purpose).
 - [Topaz](https://www.topaz.sh/) - Has AuthZEN evaluation API support. See [Zanzibar-Based](#zanzibar-based).
-- [Keycloak](https://www.keycloak.org/2026/05/authzen-as-experimental-feature) - Ships experimental AuthZEN PDP support as of Keycloak 26.7, exposing the Evaluations API and `.well-known/authzen-configuration`.
+- [Keycloak](https://www.keycloak.org/2026/05/authzen-as-experimental-feature) - Ships experimental AuthZEN PDP support as of Keycloak 26.7, exposing the evaluation API and `/.well-known/authzen-configuration`.
 
 ### Language-Specific Libraries
 


### PR DESCRIPTION
## Summary

- Keycloak 26.7 ships experimental AuthZEN PDP support: Evaluations API + `.well-known/authzen-configuration` discovery.
- First major open-source IdP shipping AuthZEN support — concrete proof-point that the spec is moving past paper into runtimes.

## Source

- https://www.keycloak.org/2026/05/authzen-as-experimental-feature