### PR TITLE
add OAuth Transaction Tokens draft to Identity & Federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 - [OpenID Connect (OIDC)](https://openid.net/developers/how-connect-works/) - Identity layer on top of OAuth 2.0.
 - [UMA 2.0 (User-Managed Access)](https://docs.kantarainitiative.org/uma/wg/rec-oauth-uma-grant-2.0.html) - OAuth-based protocol enabling users to control access to their resources.
 - [GNAP](https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol) - Grant Negotiation and Authorization Protocol. Next-gen successor to OAuth.
-- [OAuth Transaction Tokens (Draft)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-transaction-tokens) - Short-lived signed JWTs that preserve user, workload, and authorization context across multi-service call chains. In IETF OAuth WG Last Call as of March 2026.
+- [OAuth Transaction Tokens (Draft)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-transaction-tokens) - Short-lived signed JWTs that preserve user, workload, and authorization context across multi-service call chains. IETF OAuth WG draft.
 
 ### Agent & AI Authorization
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 - [OpenID Connect (OIDC)](https://openid.net/developers/how-connect-works/) - Identity layer on top of OAuth 2.0.
 - [UMA 2.0 (User-Managed Access)](https://docs.kantarainitiative.org/uma/wg/rec-oauth-uma-grant-2.0.html) - OAuth-based protocol enabling users to control access to their resources.
 - [GNAP](https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol) - Grant Negotiation and Authorization Protocol. Next-gen successor to OAuth.
+- [OAuth Transaction Tokens (Draft)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-transaction-tokens) - Short-lived signed JWTs that preserve user, workload, and authorization context across multi-service call chains. In IETF OAuth WG Last Call as of March 2026.
 
 ### Agent & AI Authorization
 


### PR DESCRIPTION
## Summary

- Adds `draft-ietf-oauth-transaction-tokens` to the Identity & Federation list. Short-lived signed JWTs that preserve user/workload/authz context across multi-service call chains — relevant to zero-trust service mesh and agent-to-service authz patterns.
- Draft is in IETF OAuth WG Last Call as of March 2026 (revision 08), matching the existing precedent of including `OAuth 2.1 (Draft)` and `GNAP` while still in-flight.

## Source

- https://datatracker.ietf.org/doc/draft-ietf-oauth-transaction-tokens/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OAuth Transaction Tokens (Draft) entry to Standards & Specifications section, documenting short-lived signed JWTs designed to preserve authorization context across multi-service call chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->