### PR TITLE
add OAuth Identity Chaining Across Domains draft to Identity & Federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 - [OpenID Connect (OIDC)](https://openid.net/developers/how-connect-works/) - Identity layer on top of OAuth 2.0.
 - [UMA 2.0 (User-Managed Access)](https://docs.kantarainitiative.org/uma/wg/rec-oauth-uma-grant-2.0.html) - OAuth-based protocol enabling users to control access to their resources.
 - [GNAP](https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol) - Grant Negotiation and Authorization Protocol. Next-gen successor to OAuth.
-- [OAuth Identity Chaining Across Domains (Draft)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-identity-chaining) - Token-exchange and JWT-grant mechanism for preserving identity and authorization across trust domains. Under IESG evaluation as of May 2026.
+- [OAuth Identity Chaining Across Domains (Draft)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-identity-chaining) - Preserves identity and authorization across OAuth trust domains by combining token exchange (RFC 8693) and JWT grants (RFC 7523). IETF OAuth WG draft.
 
 ### Agent & AI Authorization
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 - [OpenID Connect (OIDC)](https://openid.net/developers/how-connect-works/) - Identity layer on top of OAuth 2.0.
 - [UMA 2.0 (User-Managed Access)](https://docs.kantarainitiative.org/uma/wg/rec-oauth-uma-grant-2.0.html) - OAuth-based protocol enabling users to control access to their resources.
 - [GNAP](https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol) - Grant Negotiation and Authorization Protocol. Next-gen successor to OAuth.
+- [OAuth Identity Chaining Across Domains (Draft)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-identity-chaining) - Token-exchange and JWT-grant mechanism for preserving identity and authorization across trust domains. Under IESG evaluation as of May 2026.
 
 ### Agent & AI Authorization
 


### PR DESCRIPTION
## Summary

- Adds `draft-ietf-oauth-identity-chaining` to the Identity & Federation list. Combines RFC 8693 token exchange with RFC 7523 JWT grants to preserve identity and authorization across trust domains — relevant to multi-cloud, B2B federation, and CI access patterns.
- Draft is under IESG evaluation (telechat 2026-06-04) at revision 12 as of May 2026, matching the existing precedent of including `OAuth 2.1 (Draft)` and `GNAP` while still in-flight.

## Source

- https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-chaining/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new entry to the Identity & Federation standards list: "OAuth Identity Chaining Across Domains (Draft)". The entry includes a reference link and a brief description outlining the approach of combining token exchange and JWT grants for handling identity/authorization across OAuth trust domains, and notes the draft status for further review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->