### PR TITLE
remove redundant SPIFFE/SPIRE Documentation entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 
 - [SPIFFE](https://spiffe.io/) - Secure Production Identity Framework for Everyone. Provides cryptographic identity to workloads (CNCF).
 - [SPIRE](https://spiffe.io/docs/latest/spire-about/) - Production-ready SPIFFE runtime.
-- [SPIFFE/SPIRE Documentation](https://spiffe.io/docs/) - Official docs.
 
 ### Policy Standards
 


### PR DESCRIPTION
## Summary

- Drops the `SPIFFE/SPIRE Documentation` entry. Its URL `https://spiffe.io/docs/` is a redirect stub to `/docs/latest/spiffe-about/overview/` — reachable in one click from the existing SPIFFE entry, which already covers the project. The SPIRE entry already deep-links into `/docs/latest/spire-about/`.
- No information is lost; only the redundancy is.

## Source

- Independent reviewer verdict: prune (high confidence).