### PR TITLE
remove CNCF TAG-Security and now-empty Cloud Native subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,6 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 - [XACML](https://en.wikipedia.org/wiki/XACML) - XML-based standard for ABAC policies. Mature but verbose.
 - [ALFA](https://en.wikipedia.org/wiki/Abbreviated_Language_for_Authorization) - Human-readable DSL for writing XACML policies.
 
-### Cloud Native
-
-- [CNCF TAG-Security](https://tag-security.cncf.io/) - CNCF Technical Advisory Group covering authorization, policy, and security. GitHub repo archived Dec 2025.
-
 ## Authorization as a Service
 
 - [Auth0 Fine Grained Authorization](https://auth0.com/fine-grained-authorization) - Managed OpenFGA by Auth0/Okta.


### PR DESCRIPTION
## Summary

- Drops the `CNCF TAG-Security` entry. The TAG's GitHub repo (host for whitepapers and working materials) was archived 2025-12-18. The live `tag-security.cncf.io` site lists six active working groups (Automated Governance, Supply Chain, Compliance, Commons, Security Assessments, Catalog of Compromises) — none authorization-focused. The "authorization" framing of this entry was always thin and is now thinner.
- Also removes the `### Cloud Native` subsection header since this was its only entry. Cloud-native authorization is already covered by OPA, Cedar, SPIFFE/SPIRE, Kyverno in their respective sections.

## Source

- Independent reviewer verdict: prune (high confidence). Live-site WG list and repo archival confirmed.