### PR TITLE
remove Lyft Airflow DAG-Level Access as too narrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ How companies do authorization at scale.
 - [Reddit Advertising Authorization](https://www.reddit.com/r/RedditEng/comments/13vttm8/evolving_authorization_for_our_advertising/) - Fine-grained authz for their ad platform.
 - [Figma Custom Permissions DSL](https://www.figma.com/blog/how-we-rolled-out-our-own-permissions-dsl-at-figma/) - Figma built their own DSL for permissions.
 - [Intuit AuthZ](https://medium.com/intuit-engineering/authz-intuits-unified-dynamic-authorization-system-bea554d18f91) - XACML-based unified authz system.
-- [Lyft Airflow DAG-Level Access](https://eng.lyft.com/securing-apache-airflow-ui-with-dag-level-access-a7bc649a2821) - DAG-level access control on Airflow.
 - [AppsFlyer Microservices Authorization](https://medium.com/appsflyerengineering/authorization-solution-for-microservices-architecture-a2ac0c3c510b) - Authz patterns in microservices.
 - [Ubicloud ABAC Learnings](https://www.ubicloud.com/blog/learnings-from-building-a-simple-authorization-system-abac) - Lessons from building a simple ABAC system.
 - [Slack Role Management](https://slack.engineering/role-management-at-slack/) - Slack's transition from coarse roles to granular RBAC with a dedicated Go permissions service.


### PR DESCRIPTION
## Summary

- Drops the `Lyft Airflow DAG-Level Access` entry from Real-World Implementations. The 2019 article describes extending Apache Airflow's Flask-AppBuilder RBAC with two per-DAG permissions via a custom `SecurityManager` subclass — deeply tied to Airflow 1.10 / FAB internals, not transferable authz architecture.
- The rest of Real-World Implementations covers general patterns (Zanzibar-style ReBAC, centralized ABAC across microservices, custom DSLs, AI-agent permission models). The pattern this entry illustrates ("evolving from coarse roles to fine-grained, resource-scoped permissions") is already covered with broader applicability by the Slack Role Management and Figma Custom Permissions DSL entries.

## Source

- Independent reviewer verdict: prune (high confidence).