### PR TITLE
remove Warrant as superseded by listed WorkOS FGA

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Inspired by Google Zanzibar, Google's global authorization system built around r
 - [Permify](https://github.com/Permify/permify) - Zanzibar-inspired authorization service for fine-grained access control. Acquired by FusionAuth in 2025.
 - [Ory Keto](https://github.com/ory/keto) - Go implementation of Zanzibar. Part of the Ory ecosystem.
 - [Topaz](https://github.com/aserto-dev/topaz) - Open-source authorizer combining the Zanzibar model with OPA.
-- [Warrant](https://github.com/warrant-dev/warrant) - Fine-grained authorization engine, Zanzibar-inspired.
 
 ### Kubernetes-Native
 


### PR DESCRIPTION
## Summary

- Remove `Warrant` from Policy Engines & Frameworks / Zanzibar-Based. The slot held six Zanzibar engines (the most crowded in the list); Warrant is tied-lowest on stars (~1.3k) and slowest cadence since WorkOS acquired the team in 2024-04.
- Its productized successor **WorkOS FGA** is already listed under Authorization as a Service ("built on the Warrant engine"), so the lineage stays represented. Unlike SpiceDB↔Authzed / OpenFGA↔Auth0-FGA, the Warrant OSS repo is no longer the actively-developed flagship.

## Source

- https://github.com/warrant-dev/warrant (last push 2025-12-05)
- https://workos.com/fine-grained-authorization