### PR TITLE
docs: update OWASP Top 10 Broken Access Control to 2025 edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ How companies do authorization at scale.
 
 ## Security
 
-- [OWASP Top 10 - Broken Access Control](https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/) - Ranked #1 in the OWASP Top 10:2025, found in 100% of tested applications.
+- [OWASP Top 10 - Broken Access Control](https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/) - Ranked #1 in the OWASP Top 10: 2025, found in 100% of tested applications.
 - [OWASP Authorization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html) - Authz best practices.
 - [OWASP API Security Top 10](https://owasp.org/www-project-api-security/) - Top API security risks, including broken authz.
 - [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) - Framework for autonomous AI agents focusing on overprivileged non-human identities (NHI) and delegated privilege abuse.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ How companies do authorization at scale.
 
 ## Security
 
-- [OWASP Top 10 - Broken Access Control](https://owasp.org/Top10/A01_2021-Broken_Access_Control/) - #1 web security risk (2021).
+- [OWASP Top 10 - Broken Access Control](https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/) - Ranked #1 in the OWASP Top 10:2025, found in 100% of tested applications.
 - [OWASP Authorization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html) - Authz best practices.
 - [OWASP API Security Top 10](https://owasp.org/www-project-api-security/) - Top API security risks, including broken authz.
 - [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) - Framework for autonomous AI agents focusing on overprivileged non-human identities (NHI) and delegated privilege abuse.


### PR DESCRIPTION
## Summary

- Bump the OWASP Top 10 entry from the stale 2021 edition to the now-final 2025 edition. Broken Access Control retained the #1 slot (found in 100% of tested applications).

## Source

- https://owasp.org/Top10/2025/A01_2025-Broken_Access_Control/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Security section to reference OWASP Top 10 2025 standards, including the latest Broken Access Control vulnerability information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->