### PR TITLE
remove The New Stack zero-trust ebook as off-theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ How companies do authorization at scale.
 - [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) - Framework for autonomous AI agents focusing on overprivileged non-human identities (NHI) and delegated privilege abuse.
 - [Insecure Direct Object References (IDOR)](https://portswigger.net/web-security/access-control/idor) - One of the most common access control vulnerabilities.
 - [CISA/NSA IDOR Advisory](https://www.theregister.com/2023/07/29/cisa_nsa_idor_australia/) - Joint advisory on IDOR prevalence.
-- [Building a Modern Zero Trust Strategy](https://thenewstack.io/ebooks/security/trust-no-one-and-automate-almost-everything-building-a-modern-zero-trust-strategy) - Zero trust overview by The New Stack.
 
 ## Articles & Tutorials
 


### PR DESCRIPTION
## Summary

- Drop "Building a Modern Zero Trust Strategy" from the Security section. It's a zero-trust *strategy* overview (network/identity framing), not application-authorization content — the weakest-fit entry in a section that's otherwise about broken access control and authz-specific risks.

## Source

- https://thenewstack.io/ebooks/security/trust-no-one-and-automate-almost-everything-building-a-modern-zero-trust-strategy (entry being removed)